### PR TITLE
chore: update to alpine 3.7

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gliderlabs/alpine:3.4
+FROM gliderlabs/alpine:3.7
 
 RUN apk-install python
 ADD . /app

--- a/index.html
+++ b/index.html
@@ -1,1 +1,1 @@
-<h1>Powered by Deis</h1>
+<h1>Powered by Hephy</h1>


### PR DESCRIPTION
It looks like gliderlabs stopped publishing new alpine images, maybe we shouldn't link to them anymore. It looks like alpine is now up to 3.12.

(Regardless, I bumped the version here while I was testing dockerbuilder as I was here, and looking for versions – this is the latest version from gliderlabs, and it does build with the new dockerbuilder and new object-storage-cli binary upstream. 👍 )